### PR TITLE
Remove stray js alert()

### DIFF
--- a/example/public/javascripts/main.js
+++ b/example/public/javascripts/main.js
@@ -19,7 +19,6 @@ $(document).ready(function() {
 
   $('#add-word').submit(function(e) {
     e.preventDefault();
-    alert(this)
     $.ajax({
       url: '/words',
       type: 'PUT',


### PR DESCRIPTION
Spotted this when looking at the vanilla grandtour offerings that already exist before helping create the PHP one.  It's a tiny fix.